### PR TITLE
Allow adding a new markdown file

### DIFF
--- a/src/routes/ProcessModelShow.tsx
+++ b/src/routes/ProcessModelShow.tsx
@@ -158,7 +158,7 @@ export default function ProcessModelShow() {
             {primarySuffix}
           </li>
         );
-      } else if (processModelFile.name.match(/\.(json)$/)) {
+      } else if (processModelFile.name.match(/\.(json|md)$/)) {
         constructedTag = (
           <li key={processModelFile.name}>
             <Link
@@ -241,10 +241,18 @@ export default function ProcessModelShow() {
         <Button
           href={`/admin/process-models/${
             (processModel as any).process_group_id
-          }/${(processModel as any).id}/form`}
+          }/${(processModel as any).id}/form?file_ext=json`}
           variant="info"
         >
           Add New JSON File
+        </Button>
+        <Button
+          href={`/admin/process-models/${
+            (processModel as any).process_group_id
+          }/${(processModel as any).id}/form?file_ext=md`}
+          variant="info"
+        >
+          Add New Markdown File
         </Button>
       </Stack>
     );

--- a/src/routes/ReactFormEditor.tsx
+++ b/src/routes/ReactFormEditor.tsx
@@ -13,7 +13,7 @@ export default function ReactFormEditor() {
   const params = useParams();
   const [showFileNameEditor, setShowFileNameEditor] = useState(false);
   const [newFileName, setNewFileName] = useState('');
-  const [searchParams, _] = useSearchParams();
+  const searchParams = useSearchParams()[0];
   const handleShowFileNameEditor = () => setShowFileNameEditor(true);
   const navigate = useNavigate();
 

--- a/src/routes/ReactFormEditor.tsx
+++ b/src/routes/ReactFormEditor.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import Editor from '@monaco-editor/react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { Button, Modal } from 'react-bootstrap';
 import ProcessBreadcrumb from '../components/ProcessBreadcrumb';
 import HttpService from '../services/HttpService';
@@ -13,11 +13,25 @@ export default function ReactFormEditor() {
   const params = useParams();
   const [showFileNameEditor, setShowFileNameEditor] = useState(false);
   const [newFileName, setNewFileName] = useState('');
+  const [searchParams, _] = useSearchParams();
   const handleShowFileNameEditor = () => setShowFileNameEditor(true);
   const navigate = useNavigate();
 
   const [processModelFile, setProcessModelFile] = useState(null);
   const [processModelFileContents, setProcessModelFileContents] = useState('');
+
+  const fileExtension = (() => {
+    if (params.file_name) {
+      const matches = params.file_name.match(/\.([a-z]+)/);
+      if (matches !== null && matches.length > 1) {
+        return matches[1];
+      }
+    }
+
+    return searchParams.get('file_ext') ?? 'json'
+  })();
+
+  const editorDefaultLanguage = fileExtension === 'md' ? 'markdown' : 'json';
 
   useEffect(() => {
     const processResult = (result: any) => {
@@ -35,7 +49,7 @@ export default function ReactFormEditor() {
 
   const navigateToProcessModelFile = (_result: any) => {
     if (!params.file_name) {
-      const fileNameWithExtension = `${newFileName}.json`;
+      const fileNameWithExtension = `${newFileName}.${fileExtension}`;
       navigate(
         `/admin/process-models/${params.process_group_id}/${params.process_model_id}/form/${fileNameWithExtension}`
       );
@@ -48,7 +62,7 @@ export default function ReactFormEditor() {
     let fileNameWithExtension = params.file_name;
 
     if (newFileName) {
-      fileNameWithExtension = `${newFileName}.json`;
+      fileNameWithExtension = `${newFileName}.${fileExtension}`;
       httpMethod = 'POST';
     } else {
       url += `/${fileNameWithExtension}`;
@@ -103,7 +117,6 @@ export default function ReactFormEditor() {
   };
 
   const newFileNameBox = () => {
-    const fileExtension = '.json';
     return (
       <Modal show={showFileNameEditor} onHide={handleFileNameCancel}>
         <Modal.Header closeButton>
@@ -119,7 +132,7 @@ export default function ReactFormEditor() {
               onChange={(e) => setNewFileName(e.target.value)}
               autoFocus
             />
-            {fileExtension}
+            .{fileExtension}
           </span>
           <Modal.Footer>
             <Button variant="secondary" onClick={handleFileNameCancel}>
@@ -160,7 +173,7 @@ export default function ReactFormEditor() {
         <Editor
           height={600}
           width="auto"
-          defaultLanguage="json"
+          defaultLanguage={editorDefaultLanguage}
           defaultValue={processModelFileContents || ''}
           onChange={(value) => setProcessModelFileContents(value || '')}
         />

--- a/src/routes/ReactFormEditor.tsx
+++ b/src/routes/ReactFormEditor.tsx
@@ -28,7 +28,7 @@ export default function ReactFormEditor() {
       }
     }
 
-    return searchParams.get('file_ext') ?? 'json'
+    return searchParams.get('file_ext') ?? 'json';
   })();
 
   const editorDefaultLanguage = fileExtension === 'md' ? 'markdown' : 'json';


### PR DESCRIPTION
Adds a new button to allow adding a new markdown file via the editor. The editor is set to json or markdown as the default language based on the available file extension. Also made existing markdown files "clickable" so they can be opened in the editor like json files.